### PR TITLE
Self-modifying operators for constexpr complex and imaginary

### DIFF
--- a/include/static_math/complex.h
+++ b/include/static_math/complex.h
@@ -45,9 +45,19 @@ namespace smath
         using value_type = T;
 
         // Constructor
-        constexpr imaginary(value_type real);
+        constexpr imaginary(value_type real = T{0});
 
-        const value_type value;
+        //Operators
+        constexpr auto operator+=(imaginary i)
+            -> imaginary&;
+        constexpr auto operator-=(imaginary i)
+            -> imaginary&;
+        constexpr auto operator*=(T r)
+            -> imaginary&;
+        constexpr auto operator/=(T r)
+            -> imaginary&;
+
+        value_type value;
     };
 
     /**
@@ -64,9 +74,38 @@ namespace smath
         // Constructors
         constexpr complex(value_type real, value_type imag);
         constexpr complex(value_type real, imaginary<T> img);
+        constexpr complex(value_type real = T{0});
 
-        const value_type real;
-        const imaginary<T> imag;
+        // Operators
+        constexpr auto operator+=(T r)
+            -> complex&;
+        constexpr auto operator-=(T r)
+            -> complex&;
+        constexpr auto operator*=(T r)
+            -> complex&;
+        constexpr auto operator/=(T r)
+            -> complex&;
+
+        constexpr auto operator+=(imaginary<T> i)
+            -> complex&;
+        constexpr auto operator-=(imaginary<T> i)
+            -> complex&;
+        constexpr auto operator*=(imaginary<T> i)
+            -> complex&;
+        constexpr auto operator/=(imaginary<T> i)
+            -> complex&;
+
+        constexpr auto operator+=(complex o)
+            -> complex&;
+        constexpr auto operator-=(complex o)
+            -> complex&;
+        constexpr auto operator*=(complex o)
+            -> complex&;
+        constexpr auto operator/=(complex o)
+            -> complex&;
+
+        value_type real;
+        imaginary<T> imag;
     };
 
     ////////////////////////////////////////////////////////////
@@ -251,6 +290,10 @@ namespace smath
 
     template<typename T>
     constexpr auto conj(complex<T> z)
+        -> complex<T>;
+
+    template<typename T>
+    constexpr auto polar(T rho, T theta)
         -> complex<T>;
 
     inline namespace literals

--- a/include/static_math/detail/complex.inl
+++ b/include/static_math/detail/complex.inl
@@ -30,6 +30,38 @@ constexpr imaginary<T>::imaginary(value_type real):
     value(real)
 {}
 
+template<typename T>
+constexpr auto imaginary<T>::operator +=(imaginary i)
+    -> imaginary&
+{
+    value += i.value;
+    return *this;
+}
+
+template<typename T>
+constexpr auto imaginary<T>::operator -=(imaginary i)
+    -> imaginary&
+{
+    value -= i.value;
+    return *this;
+}
+
+template<typename T>
+constexpr auto imaginary<T>::operator *=(T r)
+    -> imaginary&
+{
+    value *= r;
+    return *this;
+}
+
+template<typename T>
+constexpr auto imaginary<T>::operator /=(T r)
+    -> imaginary&
+{
+    value /= r;
+    return *this;
+}
+
 ////////////////////////////////////////////////////////////
 // complex<T> functions
 
@@ -44,6 +76,118 @@ constexpr complex<T>::complex(value_type real, imaginary<T> imag):
     real(real),
     imag(imag)
 {}
+
+template<typename T>
+constexpr complex<T>::complex(value_type real):
+    real(real),
+    imag()
+{}
+
+template<typename T>
+constexpr auto complex<T>::operator +=(T r)
+    -> complex&
+{
+    real += r;
+    return *this;
+}
+
+template<typename T>
+constexpr auto complex<T>::operator -=(T r)
+    -> complex&
+{
+    real -= r;
+    return *this;
+}
+
+template<typename T>
+constexpr auto complex<T>::operator *=(T r)
+    -> complex&
+{
+    real *= r;
+    imag *= r;
+    return *this;
+}
+
+template<typename T>
+constexpr auto complex<T>::operator /=(T r)
+    -> complex&
+{
+    real /= r;
+    imag /= r;
+    return *this;
+}
+
+template<typename T>
+constexpr auto complex<T>::operator +=(imaginary<T> i)
+    -> complex&
+{
+    imag += i;
+    return *this;
+}
+
+template<typename T>
+constexpr auto complex<T>::operator -=(imaginary<T> i)
+    -> complex&
+{
+    imag -= i;
+    return *this;
+}
+
+template<typename T>
+constexpr auto complex<T>::operator *=(imaginary<T> i)
+    -> complex&
+{
+    T temp = imag * i;
+    imag = real * i;
+    real = temp;
+    return *this;
+}
+
+template<typename T>
+constexpr auto complex<T>::operator /=(imaginary<T> i)
+    -> complex&
+{
+    T temp = imag / i;
+    imag = real / i;
+    real = temp;
+    return *this;
+}
+
+template<typename T>
+constexpr auto complex<T>::operator +=(complex o)
+    -> complex&
+{
+    real += o.real;
+    imag += o.imag;
+    return *this;
+}
+
+template<typename T>
+constexpr auto complex<T>::operator -=(complex o)
+    -> complex&
+{
+    real -= o.real;
+    imag -= o.imag;
+    return *this;
+}
+
+template<typename T>
+constexpr auto complex<T>::operator *=(complex o)
+    -> complex&
+{
+    real = real*o.real + imag*o.imag;
+    imag = real*o.imag + imag*o.real;
+    return *this;
+}
+
+template<typename T>
+constexpr auto complex<T>::operator /=(complex o)
+    -> complex&
+{
+    real = (real*o.real - imag*o.imag) / (sqr(o.real) + sqr(o.imag.value));
+    imag = (imag*o.real - real*o.imag) / (sqr(o.real) + sqr(o.imag.value));
+    return *this;
+}
 
 ////////////////////////////////////////////////////////////
 // Unary arithmetic operators
@@ -481,6 +625,16 @@ constexpr auto conj(complex<T> z)
     return {
         z.real,
         -z.imag
+    };
+}
+
+template<typename T>
+constexpr auto polar(T rho, T theta)
+    -> complex<T>
+{
+    return {
+        rho * smath::cos(theta),
+        rho * smath::sin(theta)
     };
 }
 


### PR DESCRIPTION
In C++14, constexpr evaluations can modify variables, so it's nice to have compile-time classes which can be manipulated.

I wrote a [compile-time polynomial class](https://github.com/kundor/static-poly), and I wanted to use it with complex coefficients. Unfortunately, `std::complex` does not have constexpr operators, so I couldn't use it.

To use `smath::complex` instead, the member variables should not be const, and it's handy to have the self-assigning operators. This PR adds those.

I also added a polar function (like [std::polar](http://en.cppreference.com/w/cpp/numeric/complex/polar), except constexpr.)

Thanks.