### PR TITLE
Fix apple clang errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,10 @@
 *.cbp
 *.depend
 *.layout
+
+# CMake
+build*
+CMakeCache.txt
+
+# OSX
+.DS_Store

--- a/include/static_math/complex.h
+++ b/include/static_math/complex.h
@@ -31,6 +31,8 @@
 #include <static_math/cmath.h>
 #include <static_math/formula.h>
 
+#define ARITH_NUM(name) name, typename CHECK = std::enable_if_t<std::is_arithmetic< name >::value, name>
+
 namespace smath
 {
     /**
@@ -166,29 +168,29 @@ namespace smath
     constexpr auto operator/(imaginary<T> lhs, imaginary<U> rhs)
         -> std::common_type_t<T, U>;
 
-    template<typename T, typename Number>
+    template<typename T, typename ARITH_NUM(Number)>
     constexpr auto operator+(imaginary<T> lhs, Number rhs)
         -> complex<std::common_type_t<T, Number>>;
-    template<typename T, typename Number>
+    template<typename T, typename ARITH_NUM(Number)>
     constexpr auto operator-(imaginary<T> lhs, Number rhs)
         -> complex<std::common_type_t<T, Number>>;
-    template<typename T, typename Number>
+    template<typename T, typename ARITH_NUM(Number)>
     constexpr auto operator*(imaginary<T> lhs, Number rhs)
         -> imaginary<std::common_type_t<T, Number>>;
-    template<typename T, typename Number>
+    template<typename T, typename ARITH_NUM(Number)>
     constexpr auto operator/(imaginary<T> lhs, Number rhs)
         -> imaginary<std::common_type_t<T, Number>>;
 
-    template<typename T, typename Number>
+    template<typename T, typename ARITH_NUM(Number)>
     constexpr auto operator+(Number lhs, imaginary<T> rhs)
         -> complex<std::common_type_t<T, Number>>;
-    template<typename T, typename Number>
+    template<typename T, typename ARITH_NUM(Number)>
     constexpr auto operator-(Number lhs, imaginary<T> rhs)
         -> complex<std::common_type_t<T, Number>>;
-    template<typename T, typename Number>
+    template<typename T, typename ARITH_NUM(Number)>
     constexpr auto operator*(Number lhs, imaginary<T> rhs)
         -> imaginary<std::common_type_t<T, Number>>;
-    template<typename T, typename Number>
+    template<typename T, typename ARITH_NUM(Number)>
     constexpr auto operator/(Number lhs, imaginary<T> rhs)
         -> imaginary<std::common_type_t<T, Number>>;
 
@@ -205,29 +207,29 @@ namespace smath
     constexpr auto operator/(complex<T> lhs, complex<U> rhs)
         -> complex<std::common_type_t<T, U>>;
 
-    template<typename T, typename Number>
+    template<typename T, typename ARITH_NUM(Number)>
     constexpr auto operator+(complex<T> lhs, Number rhs)
         -> complex<std::common_type_t<T, Number>>;
-    template<typename T, typename Number>
+    template<typename T, typename ARITH_NUM(Number)>
     constexpr auto operator-(complex<T> lhs, Number rhs)
         -> complex<std::common_type_t<T, Number>>;
-    template<typename T, typename Number>
+    template<typename T, typename ARITH_NUM(Number)>
     constexpr auto operator*(complex<T> lhs, Number rhs)
         -> complex<std::common_type_t<T, Number>>;
-    template<typename T, typename Number>
+    template<typename T, typename ARITH_NUM(Number)>
     constexpr auto operator/(complex<T> lhs, Number rhs)
         -> complex<std::common_type_t<T, Number>>;
 
-    template<typename T, typename Number>
+    template<typename T, typename ARITH_NUM(Number)>
     constexpr auto operator+(Number lhs, complex<T> rhs)
         -> complex<std::common_type_t<T, Number>>;
-    template<typename T, typename Number>
+    template<typename T, typename ARITH_NUM(Number)>
     constexpr auto operator-(Number lhs, complex<T> rhs)
         -> complex<std::common_type_t<T, Number>>;
-    template<typename T, typename Number>
+    template<typename T, typename ARITH_NUM(Number)>
     constexpr auto operator*(Number lhs, complex<T> rhs)
         -> complex<std::common_type_t<T, Number>>;
-    template<typename T, typename Number>
+    template<typename T, typename ARITH_NUM(Number)>
     constexpr auto operator/(Number lhs, complex<T> rhs)
         -> complex<std::common_type_t<T, Number>>;
 
@@ -274,17 +276,17 @@ namespace smath
     constexpr auto operator!=(complex<T> lhs, complex<U> rhs)
         -> bool;
 
-    template<typename T, typename Number>
+    template<typename T, typename ARITH_NUM(Number)>
     constexpr auto operator==(complex<T> lhs, Number rhs)
         -> bool;
-    template<typename T, typename Number>
+    template<typename T, typename ARITH_NUM(Number)>
     constexpr auto operator!=(complex<T> lhs, Number rhs)
         -> bool;
 
-    template<typename T, typename Number>
+    template<typename T, typename ARITH_NUM(Number)>
     constexpr auto operator==(Number lhs, complex<T> rhs)
         -> bool;
-    template<typename T, typename Number>
+    template<typename T, typename ARITH_NUM(Number)>
     constexpr auto operator!=(Number lhs, complex<T> rhs)
         -> bool;
 
@@ -367,5 +369,7 @@ namespace smath
 
     #include "detail/complex.inl"
 }
+
+#undef ARITH_NUM
 
 #endif // SMATH_COMPLEX_H_

--- a/include/static_math/detail/complex.inl
+++ b/include/static_math/detail/complex.inl
@@ -22,6 +22,9 @@
  * THE SOFTWARE.
  */
 
+#undef ARITH_NUM
+#define ARITH_NUM(name) name, typename CHECK
+
 ////////////////////////////////////////////////////////////
 // imaginary<T> functions
 
@@ -288,56 +291,56 @@ constexpr auto operator/(imaginary<T> lhs, imaginary<U> rhs)
     return { lhs.value*rhs.value / sqr(rhs.value) };
 }
 
-template<typename T, typename Number>
+template<typename T, typename ARITH_NUM(Number)>
 constexpr auto operator+(imaginary<T> lhs, Number rhs)
     -> complex<std::common_type_t<T, Number>>
 {
     return { rhs, lhs };
 }
 
-template<typename T, typename Number>
+template<typename T, typename ARITH_NUM(Number)>
 constexpr auto operator-(imaginary<T> lhs, Number rhs)
     -> complex<std::common_type_t<T, Number>>
 {
     return { -rhs, lhs };
 }
 
-template<typename T, typename Number>
+template<typename T, typename ARITH_NUM(Number)>
 constexpr auto operator*(imaginary<T> lhs, Number rhs)
     -> imaginary<std::common_type_t<T, Number>>
 {
     return imaginary<std::common_type_t<T, Number>>(lhs.value * rhs);
 }
 
-template<typename T, typename Number>
+template<typename T, typename ARITH_NUM(Number)>
 constexpr auto operator/(imaginary<T> lhs, Number rhs)
     -> imaginary<std::common_type_t<T, Number>>
 {
     return imaginary<std::common_type_t<T, Number>>(lhs.value / rhs);
 }
 
-template<typename T, typename Number>
+template<typename T, typename ARITH_NUM(Number)>
 constexpr auto operator+(Number lhs, imaginary<T> rhs)
     -> complex<std::common_type_t<T, Number>>
 {
     return { lhs, rhs };
 }
 
-template<typename T, typename Number>
+template<typename T, typename ARITH_NUM(Number)>
 constexpr auto operator-(Number lhs, imaginary<T> rhs)
     -> complex<std::common_type_t<T, Number>>
 {
     return { lhs, -rhs };
 }
 
-template<typename T, typename Number>
+template<typename T, typename ARITH_NUM(Number)>
 constexpr auto operator*(Number lhs, imaginary<T> rhs)
     -> imaginary<std::common_type_t<T, Number>>
 {
     return imaginary<std::common_type_t<T, Number>>(lhs * rhs.value);
 }
 
-template<typename T, typename Number>
+template<typename T, typename ARITH_NUM(Number)>
 constexpr auto operator/(Number lhs, imaginary<T> rhs)
     -> imaginary<std::common_type_t<T, Number>>
 {
@@ -384,7 +387,7 @@ constexpr auto operator/(complex<T> lhs, complex<U> rhs)
     };
 }
 
-template<typename T, typename Number>
+template<typename T, typename ARITH_NUM(Number)>
 constexpr auto operator+(complex<T> lhs, Number rhs)
     -> complex<std::common_type_t<T, Number>>
 {
@@ -394,7 +397,7 @@ constexpr auto operator+(complex<T> lhs, Number rhs)
     };
 }
 
-template<typename T, typename Number>
+template<typename T, typename ARITH_NUM(Number)>
 constexpr auto operator-(complex<T> lhs, Number rhs)
     -> complex<std::common_type_t<T, Number>>
 {
@@ -404,7 +407,7 @@ constexpr auto operator-(complex<T> lhs, Number rhs)
     };
 }
 
-template<typename T, typename Number>
+template<typename T, typename ARITH_NUM(Number)>
 constexpr auto operator*(complex<T> lhs, Number rhs)
     -> complex<std::common_type_t<T, Number>>
 {
@@ -414,7 +417,7 @@ constexpr auto operator*(complex<T> lhs, Number rhs)
     };
 }
 
-template<typename T, typename Number>
+template<typename T, typename ARITH_NUM(Number)>
 constexpr auto operator/(complex<T> lhs, Number rhs)
     -> complex<std::common_type_t<T, Number>>
 {
@@ -424,7 +427,7 @@ constexpr auto operator/(complex<T> lhs, Number rhs)
     };
 }
 
-template<typename T, typename Number>
+template<typename T, typename ARITH_NUM(Number)>
 constexpr auto operator+(Number lhs, complex<T> rhs)
     -> complex<std::common_type_t<T, Number>>
 {
@@ -434,7 +437,7 @@ constexpr auto operator+(Number lhs, complex<T> rhs)
     };
 }
 
-template<typename T, typename Number>
+template<typename T, typename ARITH_NUM(Number)>
 constexpr auto operator-(Number lhs, complex<T> rhs)
     -> complex<std::common_type_t<T, Number>>
 {
@@ -443,7 +446,7 @@ constexpr auto operator-(Number lhs, complex<T> rhs)
         -rhs.imag
     };
 }
-template<typename T, typename Number>
+template<typename T, typename ARITH_NUM(Number)>
 constexpr auto operator*(Number lhs, complex<T> rhs)
     -> complex<std::common_type_t<T, Number>>
 {
@@ -453,7 +456,7 @@ constexpr auto operator*(Number lhs, complex<T> rhs)
     };
 }
 
-template<typename T, typename Number>
+template<typename T, typename ARITH_NUM(Number)>
 constexpr auto operator/(Number lhs, complex<T> rhs)
     -> complex<std::common_type_t<T, Number>>
 {
@@ -575,7 +578,7 @@ constexpr auto operator!=(complex<T> lhs, complex<U> rhs)
     return !(lhs == rhs);
 }
 
-template<typename T, typename Number>
+template<typename T, typename ARITH_NUM(Number)>
 constexpr auto operator==(complex<T> lhs, Number rhs)
     -> bool
 {
@@ -583,14 +586,14 @@ constexpr auto operator==(complex<T> lhs, Number rhs)
         && lhs.imag.value == 0;
 }
 
-template<typename T, typename Number>
+template<typename T, typename ARITH_NUM(Number)>
 constexpr auto operator!=(complex<T> lhs, Number rhs)
     -> bool
 {
     return !(lhs == rhs);
 }
 
-template<typename T, typename Number>
+template<typename T, typename ARITH_NUM(Number)>
 constexpr auto operator==(Number lhs, complex<T> rhs)
     -> bool
 {
@@ -598,7 +601,7 @@ constexpr auto operator==(Number lhs, complex<T> rhs)
         && rhs.imag_value == 0;
 }
 
-template<typename T, typename Number>
+template<typename T, typename ARITH_NUM(Number)>
 constexpr auto operator!=(Number lhs, complex<T> rhs)
     -> bool
 {

--- a/include/static_math/detail/core.h
+++ b/include/static_math/detail/core.h
@@ -59,14 +59,16 @@ namespace detail
     ////////////////////////////////////////////////////////////
     // Minimal and maximal values
 
-    template<typename T, typename U>
+    template<typename T, typename U,
+             typename = std::enable_if_t<std::is_arithmetic<T>::value && std::is_arithmetic<U>::value>>
     constexpr auto min(T first, U second)
         -> std::common_type_t<T, U>
     {
         return (first < second) ? first : second;
     }
 
-    template<typename T, typename U, typename... Rest>
+    template<typename T, typename U, typename... Rest,
+             typename = std::enable_if_t<std::is_arithmetic<T>::value && std::is_arithmetic<U>::value>>
     constexpr auto min(T first, U second, Rest... rest)
         -> std::common_type_t<T, U, Rest...>
     {
@@ -82,14 +84,16 @@ namespace detail
         return {};
     }
 
-    template<typename T, typename U>
+    template<typename T, typename U,
+             typename = std::enable_if_t<std::is_arithmetic<T>::value && std::is_arithmetic<U>::value>>
     constexpr auto max(T first, U second)
         -> std::common_type_t<T, U>
     {
         return (first > second) ? first : second;
     }
 
-    template<typename T, typename U, typename... Rest>
+    template<typename T, typename U, typename... Rest,
+             typename = std::enable_if_t<std::is_arithmetic<T>::value && std::is_arithmetic<U>::value>>
     constexpr auto max(T first, U second, Rest... rest)
         -> std::common_type_t<T, U, Rest...>
     {

--- a/test/complex.cpp
+++ b/test/complex.cpp
@@ -43,12 +43,12 @@ constexpr auto test(complex<int> lhs, complex<long long> rhs)
 int main()
 {
     // Constructor tests
-    constexpr imaginary<int> i1;
+    constexpr imaginary<int> i1{};
     static_assert(i1.value == 0, "");
     constexpr auto i2 = imaginary<float>(5.8f);
     static_assert(smath::is_close(i2.value, 5.8f), "");
 
-    constexpr complex<int> c1;
+    constexpr complex<int> c1{};
     static_assert(c1.real == 0, "");
     static_assert(c1.imag.value == 0, "");
     constexpr auto c2 = complex<float>(1.2f, 2.5f);


### PR DESCRIPTION
This fixes the issues I opened in #8. 

I tried to split them up into separate commits if you want to `cherry-pick`. I'm not particularly proud of the complex solution. 

I tested this with gcc-5, clang 3.7 and Apple Clang. 