### PR TITLE
Add Travis CI support and CMake

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,121 @@
+
+language: cpp
+
+git:
+    depth: 5
+
+addons: 
+  apt:
+    sources:
+    - ubuntu-toolchain-r-test # cmake requirement
+    - george-edison55-precise-backports
+    
+    packages:
+    - [cmake, cmake-data]
+    - ccache
+    - ninja-build
+    - [gcc-5, g++-5]
+
+matrix:
+  allow_failures:
+    - os: linux
+      compiler: clang
+
+  include: 
+    # Linux
+
+    ## Clang
+    - os: linux
+      env: COMPILER=clang++ CMAKE_BUILD_TYPE=Release CMAKE_GENERATOR=Ninja
+      compiler: clang
+
+    - os: linux
+      env: COMPILER=clang++ CMAKE_BUILD_TYPE=Debug CMAKE_GENERATOR=Ninja
+      compiler: clang
+
+    ## gcc
+    - os: linux
+      env: COMPILER=g++-5 CMAKE_BUILD_TYPE=Debug CMAKE_GENERATOR=Ninja
+      compiler: gcc
+          
+    - os: linux
+      env: COMPILER=g++-5 CMAKE_BUILD_TYPE=Release CMAKE_GENERATOR=Ninja
+      compiler: gcc
+        
+
+    # Mac OSX
+    - os: osx
+      osx_image: xcode7
+      compiler: clang
+      env: CMAKE_BUILD_TYPE=Debug CMAKE_GENERATOR=Ninja 
+
+    - os: osx
+      osx_image: xcode7
+      compiler: gcc
+      env: CMAKE_BUILD_TYPE=Release CMAKE_GENERATOR=Ninja
+
+    - os: osx
+      osx_image: xcode7
+      compiler: clang
+      env: CMAKE_BUILD_TYPE=Release CMAKE_GENERATOR=Ninja 
+
+    - os: osx
+      osx_image: xcode7
+      compiler: clang
+      env: CMAKE_BUILD_TYPE=Debug CMAKE_GENERATOR=Xcode  
+
+cache:
+  directories:
+    - $HOME/.ccache
+
+before_install:
+- |
+    case `uname` in 
+        Darwin)     export OS_NAME="osx"    ;;
+        Linux)      export OS_NAME="linux"  ;;
+    esac
+
+    if [[ ${OS_NAME} == osx ]]; then
+        brew install cmake ninja
+    fi
+
+- |
+    if [[ ${OS_NAME} == linux ]]; then
+        case ${COMPILER} in
+            clang*)
+                export CC=$(echo ${COMPILER} | sed 's/\+//g')
+                export CXX=${COMPILER}
+            ;;
+
+            g++-*)
+                export CC=$(echo ${COMPILER} | sed 's/\+/c/g')
+                export CXX=${COMPILER} 
+            ;;
+
+            *) echo "Invalid compiler version" ; exit 2 ;;
+        esac
+    fi
+
+script:
+
+- |
+  cmake --version
+  ninja --version 
+
+  echo "CC=${CC}"
+  $CC --version
+  echo "CXX=${CXX}"
+  $CXX --version
+
+- mkdir build; cd build
+- |
+    cmake -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} \
+          -G${CMAKE_GENERATOR} \
+          ..
+
+- cmake --build . --target check
+
+notifications:
+    email:
+        on_success: change
+        on_failure: change

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,86 @@
+cmake_minimum_required(VERSION 3.0)
+project(static_math)
+
+set(CMAKE_CXX_STANDARD 14)
+
+option(STATIC_MATH_BUILD_TESTS  "Build the tests them." ON)
+option(USE_CCACHE               "Use `ccache` if available"         ON)
+
+if (NOT CMAKE_BUILD_TYPE)
+    if(CMAKE_GENERATOR STREQUAL "Xcode")
+        set(CMAKE_BUILD_TYPE "Debug")
+    else()
+        set(CMAKE_BUILD_TYPE "Release")
+    endif()
+    
+    message(STATUS "No build type selected, default to ${CMAKE_BUILD_TYPE}")
+endif()
+
+if (USE_CCACHE)
+    find_program(CCACHE_FOUND ccache)
+
+    if (CCACHE_FOUND)
+        message(STATUS "Using ccache")
+    
+        set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ccache)
+        set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK ccache) 
+    endif(CCACHE_FOUND)
+endif(USE_CCACHE)
+
+set(headers include/static_math/cmath.h
+            include/static_math/complex.h
+            include/static_math/constant.h
+            include/static_math/constants.h
+            include/static_math/formula.h
+            include/static_math/rational.h
+            include/static_math/static_math.h
+            include/static_math/trigonometry.h
+            include/static_math/vector.h)
+
+set(detail_headers
+            include/static_math/detail/can_fit.h
+            include/static_math/detail/cmath.inl
+            include/static_math/detail/complex.inl
+            include/static_math/detail/constant.inl
+            include/static_math/detail/core.h
+            include/static_math/detail/formula.inl
+            include/static_math/detail/parse.h
+            include/static_math/detail/rational.inl
+            include/static_math/detail/trigonometry.inl
+            include/static_math/detail/vector.inl)
+
+install(DIRECTORY include/
+        DESTINATION include/)
+
+if (STATIC_MATH_BUILD_TESTS)
+    include(CTest)
+    enable_testing()
+
+    include_directories(./include)
+    # Generate all of the example parsers
+    function(build_test test_tgt check_tgt)
+        
+        # Add executable for the example
+        add_executable(test-${test_tgt} ${headers} ${detail_headers} test/${test_tgt}.cpp)
+        add_test(NAME ${test_tgt}
+                COMMAND test-${test_tgt})
+
+        if(TARGET ${check_tgt})
+            add_dependencies(${check_tgt} test-${test_tgt})
+        endif()
+    endfunction(build_test)
+
+    add_custom_target(all_tests ALL)
+
+    build_test(cmath        all_tests)
+    build_test(complex      all_tests)
+    build_test(constant     all_tests)
+    build_test(formula      all_tests)
+    build_test(rational     all_tests)
+    build_test(trigonometry all_tests)
+    build_test(vector       all_tests)
+
+    add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND} -C "${CMAKE_BUILD_TYPE}" --output-on-failure
+                            DEPENDS all_tests
+                            VERBATIM)
+endif()


### PR DESCRIPTION
* Travis:
  * We ignore linux + clang becuase the clang version, 3.4, is ancient

* To build "tests":
  * `mkdir build && cd build/`
  * `cmake ..`
  * `cmake --build . --target check`

* To build for an IDE
  * Xcode:
    * `cd build/;`
    * `cmake .. -GXcode`

  * Code blocks:
    * `cmake .. -G"CodeBlocks - Unix Makefiles"`

  * Visual Studio:
    * `cmake .. -G"Visual Studio 14 2015 Win64"`

I don't think Travis will pass until the other problems are fixed. The OSX tests will fail at least. 