### PR TITLE
Make real-complex comparison commutative again...

### DIFF
--- a/include/static_math/detail/complex.inl
+++ b/include/static_math/detail/complex.inl
@@ -595,7 +595,7 @@ constexpr auto operator==(Number lhs, complex<T> rhs)
     -> bool
 {
     return rhs.real == lhs
-        && rhs.imag_value == 0;
+        && rhs.imag.value == 0;
 }
 
 template<typename T, typename Number, typename>

--- a/test/complex.cpp
+++ b/test/complex.cpp
@@ -75,10 +75,15 @@ int main()
     static_assert(5 == comp0, "");
     static_assert(comp0 == 5, "");
     static_assert(comp1 == imag1, "");
+    static_assert(imag1 == comp1, "");
     static_assert(comp0 == comp3, "");
+    static_assert(comp3 == comp0, "");
     static_assert(comp0 != 3, "");
+    static_assert(3 != comp0, "");
     static_assert(imag0 != imag1, "");
+    static_assert(imag1 != imag0, "");
     static_assert(comp0 != comp1, "");
+    static_assert(comp1 != comp0, "");
 
     // imaginary-imaginary arithmetic
     static_assert(imag1 + imag1 == 2_i, "");

--- a/test/complex.cpp
+++ b/test/complex.cpp
@@ -72,6 +72,7 @@ int main()
     static_assert(-comp0 == complex<int>(-5, 0), "");
 
     // Comparison tests
+    static_assert(5 == comp0, "");
     static_assert(comp0 == 5, "");
     static_assert(comp1 == imag1, "");
     static_assert(comp0 == comp3, "");


### PR DESCRIPTION
Due to a typo and poor test coverage, comparison with a real value
on the LHS would not compile.