### PR TITLE
Add lround and llround

### DIFF
--- a/include/static_math/cmath.h
+++ b/include/static_math/cmath.h
@@ -103,6 +103,14 @@ namespace smath
         -> decltype(std::round(x));
 
     template<typename Float>
+    constexpr auto lround(Float x)
+        -> decltype(std::lround(x));
+
+    template<typename Float>
+    constexpr auto llround(Float x)
+        -> decltype(std::llround(x));
+
+    template<typename Float>
     constexpr auto trunc(Float x)
         -> decltype(std::trunc(x));
 

--- a/include/static_math/detail/cmath.inl
+++ b/include/static_math/detail/cmath.inl
@@ -583,6 +583,20 @@ constexpr auto round(Float x)
 }
 
 template<typename Float>
+constexpr auto lround(Float x)
+    -> decltype(std::lround(x))
+{
+    return (x >= 0.0) ? long(x + 0.5) : long(x - 0.5);
+}
+
+template<typename Float>
+constexpr auto llround(Float x)
+    -> decltype(std::llround(x))
+{
+    return (x >= 0.0) ? (long long)(x + 0.5) : (long long)(x - 0.5);
+}
+
+template<typename Float>
 constexpr auto trunc(Float x)
     -> decltype(std::trunc(x))
 {

--- a/test/cmath.cpp
+++ b/test/cmath.cpp
@@ -62,6 +62,7 @@ int main()
     static_assert(smath::floor(2.8) == 2.0, "");
     static_assert(smath::floor(-2.5) == -3.0, "");
 
+    static_assert(smath::ceil(0) == 0.0, "");
     static_assert(smath::ceil(2.5) == 3.0, "");
     static_assert(smath::ceil(2.01) == 3.0, "");
     static_assert(smath::ceil(2.8) == 3.0, "");
@@ -71,6 +72,20 @@ int main()
     static_assert(smath::round(2.01) == 2.0, "");
     static_assert(smath::round(2.8) == 3.0, "");
     static_assert(smath::round(-2.1) == -2.0, "");
+
+    static_assert(smath::lround(6000000000.5)== 6000000001, "");
+    static_assert(smath::lround(2.5) == 3.0, "");
+    static_assert(smath::lround(2.01) == 2.0, "");
+    static_assert(smath::lround(2.8) == 3.0, "");
+    static_assert(smath::lround(-2.1) == -2.0, "");
+    static_assert(smath::lround(-6000000000.5) == -6000000001, "");
+
+    static_assert(smath::llround(6000000000.5)== 6000000001, "");
+    static_assert(smath::llround(2.5) == 3.0, "");
+    static_assert(smath::llround(2.01) == 2.0, "");
+    static_assert(smath::llround(2.8) == 3.0, "");
+    static_assert(smath::llround(-2.1) == -2.0, "");
+    static_assert(smath::llround(-6000000000.5) == -6000000001, "");
 
     static_assert(smath::trunc(2.5) == 2.0, "");
     static_assert(smath::trunc(2.01) == 2.0, "");


### PR DESCRIPTION
Only difference between the existing round and these new ones is the deduced return type from lround and llround, and the explicit coersion to long and long-long.