### PR TITLE
STATIC_MATH_BUILD_TESTS default should be OFF

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 
 project(static_math LANGUAGES CXX)
 
-option(STATIC_MATH_BUILD_TESTS "Build the tests them." ON)
+option(STATIC_MATH_BUILD_TESTS "Build the tests them." OFF)
 
 # Create static_math library and configure it
 add_library(static_math INTERFACE)


### PR DESCRIPTION
The default value for the option STATIC_MATH_BUILD_TESTS should be OFF. Users generally don't want to build your tests. :wink: 